### PR TITLE
Add azure support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires=
     dvc-objects>=0.0.13
     funcy>=1.14
     requests==2.28.0
-    universal-pathlib==0.0.18
+    universal-pathlib==0.0.19
 
 [options.entry_points]
 pytest11 =
@@ -50,11 +50,16 @@ s3 =
     moto[server]==3.1.14
     s3fs[boto3]>=2022.02.0; python_version < '3.11'
 
+azure =
+    adlfs>=2022.02.22; python_version < '3.11'
+    docker>=5.0.3; sys_platform != 'win32'
+
 dev =
     %(tests)s
 
 all =
     %(s3)s
+    %(azure)s
 
 
 [options.packages.find]

--- a/src/pytest_servers/azure.py
+++ b/src/pytest_servers/azure.py
@@ -1,0 +1,59 @@
+import logging
+import time
+
+import pytest
+import requests
+
+AZURITE_PORT = 10000
+AZURITE_URL = "http://localhost:{port}"
+AZURITE_ACCOUNT_NAME = "devstoreaccount1"
+AZURITE_KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="  # noqa: E501
+AZURITE_ENDPOINT = f"{AZURITE_URL}/{AZURITE_ACCOUNT_NAME}"
+AZURITE_CONNECTION_STRING = f"DefaultEndpointsProtocol=http;AccountName={AZURITE_ACCOUNT_NAME};AccountKey={AZURITE_KEY};BlobEndpoint={AZURITE_ENDPOINT};"  # noqa: E501
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session")
+def azurite(docker_client):
+    if docker_client is None:
+        logger.warning(
+            "Azurite cannot be started because docker is not available."
+        )
+        yield None
+        return
+
+    container = docker_client.containers.run(
+        "mcr.microsoft.com/azure-storage/azurite",
+        command="azurite-blob --loose --blobHost 0.0.0.0",
+        name="pytest-servers-azurite",
+        stdout=True,
+        stderr=True,
+        detach=True,
+        remove=True,
+        ports={f"{AZURITE_PORT}/tcp": None},  # assign a random port
+    )
+
+    port = docker_client.api.port("pytest-servers-azurite", AZURITE_PORT)[0][
+        "HostPort"
+    ]
+    retries = 3
+    while True:
+        try:
+            # wait until the container is up, even a 400 status code is ok
+            r = requests.get(AZURITE_URL.format(port=port), timeout=10)
+            if (
+                r.status_code == 400
+                and "Server" in r.headers
+                and "Azurite" in r.headers["Server"]
+            ):
+                break
+        except Exception as e:  # noqa: E722 # pylint: disable=broad-except
+            retries -= 1
+            if retries < 0:
+                raise SystemError from e
+            time.sleep(1)
+
+    yield AZURITE_CONNECTION_STRING.format(port=port)
+
+    container.stop()

--- a/src/pytest_servers/exceptions.py
+++ b/src/pytest_servers/exceptions.py
@@ -1,0 +1,14 @@
+class PytestServersException(Exception):
+    """Base class for all pytest-servers exceptions."""
+
+    def __init__(self, msg: str, *args):
+        assert msg
+        self.msg = msg
+        super().__init__(msg, *args)
+
+
+class RemoteUnavailable(PytestServersException):
+    """Raise when the given remote is not available"""
+
+    def __init__(self, remote: str, *args):
+        super().__init__(f"{remote} remote is not available", *args)

--- a/src/pytest_servers/factory.py
+++ b/src/pytest_servers/factory.py
@@ -4,8 +4,9 @@ from typing import TYPE_CHECKING, Optional
 from pytest import TempPathFactory
 from upath import UPath
 
+from pytest_servers.exceptions import RemoteUnavailable
 from pytest_servers.local import LocalPath
-from pytest_servers.utils import random_string
+from pytest_servers.utils import random_string, skip_or_raise_on
 
 if TYPE_CHECKING:
     from pytest import Config
@@ -14,26 +15,28 @@ if TYPE_CHECKING:
 class TempUPathFactory:
     """Factory for temporary directories with universal-pathlib and mocked servers"""  # noqa: E501
 
-    def __init__(self):
-        self._local_path_factory = None
-        self._s3_endpoint_url = None
+    def __init__(
+        self,
+        s3_endpoint_url: Optional[str] = None,
+        azure_connection_string: Optional[str] = None,
+    ):
+        self._local_path_factory: Optional["TempPathFactory"] = None
+        self._s3_endpoint_url = s3_endpoint_url
+        self._azure_connection_string = azure_connection_string
 
     @classmethod
     def from_config(
-        cls, config: "Config", s3_endpoint_url: Optional[str] = None
+        cls, config: "Config", *args, **kwargs
     ) -> "TempUPathFactory":
-        """Create a factory according to pytest configuration.
-
-        :meta private:
-        """
-        tmp_upath_factory = cls()
+        """Create a factory according to pytest configuration."""
+        tmp_upath_factory = cls(*args, **kwargs)
         tmp_upath_factory._local_path_factory = TempPathFactory.from_config(
             config, _ispytest=True
         )
-        tmp_upath_factory._s3_endpoint_url = s3_endpoint_url
 
         return tmp_upath_factory
 
+    @skip_or_raise_on(ImportError, RemoteUnavailable)
     def mktemp(self, fs: str = "local") -> "UPath":
         """Create a new temporary directory managed by the factory.
 
@@ -44,25 +47,35 @@ class TempUPathFactory:
             :class:`upath.Upath` to the new directory.
         """
         if fs == "local":
-            mktemp = (
-                self._local_path_factory.mktemp
-                if self._local_path_factory
-                else tempfile.mktemp
-            )
-            return LocalPath(mktemp("pytest-servers"))
-
+            return self.local_temp_path()
         elif fs == "s3":
+            if not self._s3_endpoint_url:
+                raise RemoteUnavailable("S3")
             return self.s3_temp_path(
-                "eu-south-1", endpoint_url=self._s3_endpoint_url
+                region_name="eu-south-1", endpoint_url=self._s3_endpoint_url
+            )
+        elif fs == "azure":
+            if not self._azure_connection_string:
+                raise RemoteUnavailable("Azure")
+            return self.azure_temp_path(
+                connection_string=self._azure_connection_string  # type: ignore
             )
         else:
             raise ValueError(fs)
+
+    def local_temp_path(self):
+        mktemp = (
+            self._local_path_factory.mktemp
+            if self._local_path_factory is not None
+            else tempfile.mktemp
+        )
+        return LocalPath(mktemp("pytest-servers"))
 
     def s3_temp_path(
         self,
         region_name: str,
         endpoint_url: Optional[str] = None,
-    ):
+    ) -> UPath:
         """Creates a new S3 bucket and returns an UPath instance  .
 
         endpoint_url can be used to use custom servers (e.g. moto s3)."""
@@ -74,5 +87,15 @@ class TempUPathFactory:
 
         bucket_name = f"pytest-servers-{random_string()}"
         path = UPath(f"s3://{bucket_name}", client_kwargs=client_kwargs)
+        path.mkdir()
+        return path
+
+    def azure_temp_path(self, connection_string: str) -> UPath:
+        """Creates a new container and returns an UPath instance"""
+        container_name = f"pytest-servers-{random_string()}"
+        path = UPath(
+            f"az://{container_name}",
+            connection_string=connection_string,
+        )
         path.mkdir()
         return path

--- a/src/pytest_servers/s3.py
+++ b/src/pytest_servers/s3.py
@@ -83,6 +83,5 @@ def s3_server(
     s3_fake_creds_file,  # pylint: disable=unused-argument,redefined-outer-name
 ):
     """Spins up a moto s3 server."""
-    pytest.importorskip("s3fs")
     with MockedS3Server(request.config.getoption("--moto-port")) as server:
         yield server

--- a/src/pytest_servers/utils.py
+++ b/src/pytest_servers/utils.py
@@ -1,8 +1,13 @@
+import logging
+import os
 import random
 import string
 import time
 
 import pytest
+from funcy import decorator
+
+logger = logging.getLogger(__name__)
 
 
 def wait_until(pred, timeout: float, pause: float = 0.1):
@@ -27,3 +32,43 @@ def monkeypatch_session():
     m = MonkeyPatch()
     yield m
     m.undo()
+
+
+@pytest.fixture(scope="session")
+def docker_client():
+    """Run docker commands using the python API"""
+    if os.environ.get("CI") and os.name == "nt":
+        # docker-py currently fails to pull images on windows (?)
+        yield None
+        return
+
+    try:
+        import docker
+    except ImportError:
+        logger.warning("docker is not installed, run pip install docker")
+        yield None
+        return
+
+    try:
+        yield docker.from_env()
+    except docker.errors.DockerException as exc:
+        logging.exception(f"Failed to get docker client: {exc}")
+        yield None
+
+
+def is_pytest_session() -> bool:
+    """returns true if currently running a pytest session"""
+    return "PYTEST_CURRENT_TEST" in os.environ
+
+
+@decorator
+def skip_or_raise_on(call, *exceptions):
+    """If in a pytest session, skips the current test when the given exceptions are raised"""  # noqa: E501
+    try:
+        return call()
+    except exceptions as exc:
+        if is_pytest_session():
+            # just get the test name
+            current_test = os.environ["PYTEST_CURRENT_TEST"].split()[0]
+            pytest.skip(f"{current_test}: {exc}")
+        raise

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -17,7 +17,13 @@ class TestFactory:
         assert s3_path.exists()
         assert list(s3_path.iterdir()) == []
 
-    @pytest.mark.parametrize("fs", ["local", "s3"])
+    def test_azure_path(self, tmp_upath_factory):
+        azure_path = tmp_upath_factory.mktemp("azure")
+        assert isinstance(azure_path, upath.implementations.cloud.AzurePath)
+        assert azure_path.exists()
+        assert list(azure_path.iterdir()) == []
+
+    @pytest.mark.parametrize("fs", ["local", "s3", "azure"])
     def test_multiple_paths(self, tmp_upath_factory, fs):
         path_1 = tmp_upath_factory.mktemp(fs)
         path_2 = tmp_upath_factory.mktemp(fs)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -3,6 +3,15 @@ import upath
 
 from pytest_servers.local import LocalPath
 
+try:
+    import adlfs
+except ImportError:
+    adlfs = None
+try:
+    import s3fs
+except ImportError:
+    s3fs = None
+
 
 class TestFactory:
     def test_local_path(self, tmp_upath_factory):
@@ -12,18 +21,37 @@ class TestFactory:
         assert list(local_path.iterdir()) == []
 
     def test_s3_path(self, tmp_upath_factory):
+        pytest.importorskip("s3fs")
         s3_path = tmp_upath_factory.mktemp("s3")
         assert isinstance(s3_path, upath.implementations.cloud.S3Path)
         assert s3_path.exists()
         assert list(s3_path.iterdir()) == []
 
     def test_azure_path(self, tmp_upath_factory):
+        pytest.importorskip("adlfs")
         azure_path = tmp_upath_factory.mktemp("azure")
         assert isinstance(azure_path, upath.implementations.cloud.AzurePath)
         assert azure_path.exists()
         assert list(azure_path.iterdir()) == []
 
-    @pytest.mark.parametrize("fs", ["local", "s3", "azure"])
+    @pytest.mark.parametrize(
+        "fs",
+        [
+            "local",
+            pytest.param(
+                "s3",
+                marks=pytest.mark.skipif(
+                    s3fs is None, reason="'s3fs' is not available"
+                ),
+            ),
+            pytest.param(
+                "azure",
+                marks=pytest.mark.skipif(
+                    adlfs is None, reason="'adlfs' is not available"
+                ),
+            ),
+        ],
+    )
     def test_multiple_paths(self, tmp_upath_factory, fs):
         path_1 = tmp_upath_factory.mktemp(fs)
         path_2 = tmp_upath_factory.mktemp(fs)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,16 @@
 import os
 from pathlib import Path
 
+from pytest_servers.utils import is_pytest_session
 
-def test_s3_fake_creds_file(s3_fake_creds_file):
+
+def test_is_pytest_session():
+    assert is_pytest_session()
+
+
+def test_s3_fake_creds_file(
+    s3_fake_creds_file,  # pylint: disable=unused-argument
+):
     assert os.getenv("AWS_PROFILE") is None
     assert os.getenv("AWS_ACCESS_KEY_ID") == "pytest-servers"
     assert os.getenv("AWS_SECRET_ACCESS_KEY") == "pytest-servers"


### PR DESCRIPTION
This is accomplished through the `azurite` fixture, which spins up azurite in a docker container and returns the connection string.

Mocking Azure (with azurite) requires `docker-py`, which might fail on windows. `docker-py` might be swapped for `pytest-docker` or some other mechanism in the near future.
