### PR TITLE
fix LocalPath

### DIFF
--- a/src/pytest_servers/local.py
+++ b/src/pytest_servers/local.py
@@ -1,6 +1,6 @@
 import pathlib
 
-from fsspec.implementations.local import LocalFileSystem
+from dvc_objects.fs.implementations.local import LocalFileSystem
 
 
 class LocalPath(type(pathlib.Path())):  # type: ignore[misc]


### PR DESCRIPTION
#12 breaks  dvc-data tests (`test_db.py::test_db`
```console
/home/dtrifiro/work/dvc-data/tests/hashfile/test_db.py:5:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <dvc_data.hashfile.db.HashFileDB object at 0x7fdbb6a51b70>, fs = <fsspec.implementations.local.LocalFileSystem object at 0x7fdbb6eb6fb0>
path = LocalPath('/tmp/pytest-of-dtrifiro/pytest-106/pytest-servers0'), config = {}, StateNoop = <class 'dvc_data.hashfile.state.StateNoop'>

    def __init__(self, fs: "FileSystem", path: str, **config):
        from .state import StateNoop

        super().__init__(fs, path)
        self.state = config.get("state", StateNoop())
        self.verify = config.get("verify", self.DEFAULT_VERIFY)
        self.cache_types = config.get("type") or copy(self.DEFAULT_CACHE_TYPES)
        self.slow_link_warning = config.get("slow_link_warning", True)
        self.tmp_dir = config.get("tmp_dir")
        self.read_only = config.get("read_only", False)
>       self.hash_name = config.get("hash_name", self.fs.PARAM_CHECKSUM)
E       AttributeError: 'LocalFileSystem' object has no attribute 'PARAM_CHECKSUM'
```