### PR TITLE
TmpUPathFactory: Add support for Google Cloud Storage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,13 @@ s3 =
 
 azure =
     adlfs>=2022.02.22; python_version < '3.11'
+    %(docker)s
+
+gcs =
+    gcsfs>=2022.02.22; python_version < '3.11'
+    %(docker)s
+
+docker =
     docker>=5.0.3; sys_platform != 'win32'
 
 dev =
@@ -61,6 +68,7 @@ dev =
 all =
     %(s3)s
     %(azure)s
+    %(gcs)s
 
 
 [options.packages.find]

--- a/src/pytest_servers/azure.py
+++ b/src/pytest_servers/azure.py
@@ -48,10 +48,10 @@ def azurite(docker_client):
                 and "Azurite" in r.headers["Server"]
             ):
                 break
-        except Exception as e:  # noqa: E722 # pylint: disable=broad-except
+        except Exception as exc:  # noqa: E722 # pylint: disable=broad-except
             retries -= 1
             if retries < 0:
-                raise SystemError from e
+                raise SystemError from exc
             time.sleep(1)
 
     yield AZURITE_CONNECTION_STRING.format(port=port)

--- a/src/pytest_servers/gcs.py
+++ b/src/pytest_servers/gcs.py
@@ -1,0 +1,54 @@
+import logging
+import time
+
+import pytest
+import requests
+
+from .utils import get_free_port
+
+logger = logging.getLogger(__name__)
+
+GCS_DEFAULT_PORT = 4443
+
+
+@pytest.fixture(scope="session")
+def fake_gcs_server(docker_client):
+    if docker_client is None:
+        logger.warning(
+            "fake-gcs-server cannot run because docker is not available."
+        )
+        yield None
+        return
+
+    # Some features, such as signed URLs and resumable uploads, require
+    # `fake-gcs-server` to know the actual url it will be accessed
+    # with. We can provide that with -public-host and -external-url.
+    port = get_free_port()
+    url = f"http://localhost:{port}"
+    command = f"-scheme http -public-host {url} -external-url {url}"
+
+    container = docker_client.containers.run(
+        "fsouza/fake-gcs-server:latest",
+        command=command,
+        name="pytest-servers-fake-gcs-server",
+        stdout=True,
+        stderr=True,
+        detach=True,
+        remove=True,
+        ports={f"{GCS_DEFAULT_PORT}/tcp": port},
+    )
+    retries = 3
+    while True:
+        try:
+            r = requests.get(f"{url}/storage/v1/b", timeout=10)
+            if r.ok:
+                break
+        except Exception as exc:  # noqa: E722 # pylint: disable=broad-except
+            retries -= 1
+            if retries < 0:
+                raise SystemError from exc
+            time.sleep(1)
+
+    yield url
+
+    container.stop()

--- a/src/pytest_servers/utils.py
+++ b/src/pytest_servers/utils.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import random
+import socket
 import string
 import time
 
@@ -72,3 +73,17 @@ def skip_or_raise_on(call, *exceptions):
             current_test = os.environ["PYTEST_CURRENT_TEST"].split()[0]
             pytest.skip(f"{current_test}: {exc}")
         raise
+
+
+def get_free_port() -> None:
+    retries = 3
+    while retries >= 0:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.listen()
+                free_port = s.getsockname()[1]
+            return free_port
+        except OSError as exc:
+            retries -= 1
+            if retries <= 0:
+                raise SystemError("Could not get a free port") from exc


### PR DESCRIPTION
Google Cloud Storage is mocked using `fake-gcs-server` (https://github.com/fsouza/fake-gcs-server), run via docker