### PR TITLE
s3: make moto use a random port by default

### DIFF
--- a/src/pytest_servers/fixtures.py
+++ b/src/pytest_servers/fixtures.py
@@ -67,14 +67,3 @@ def tmp_upath(
     elif param == "azure":
         return tmp_upath_factory.mktemp("azure")
     raise ValueError(f"unknown {param=}")
-
-
-def pytest_addoption(parser):
-    """Adds flags to configure mock remotes paths"""
-    group = parser.getgroup("pytest-servers", "pytest-servers options")
-
-    group.addoption(
-        "--moto-port",
-        help="Port for moto s3 server (defaults to %(default)s)",
-        default=MockedS3Server.DEFAULT_PORT,
-    )


### PR DESCRIPTION
Using `0` as default port for moto chooses a random port. This also gets rid of the `--moto-port` pytest argument