### PR TITLE
ci: ignore errors on 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,11 +46,12 @@ jobs:
         nox --version
 
     - name: Lint code and check dependencies
-      if: matrix.pyv != '3.11-dev'
+      continue-on-error: ${{ matrix.pyv == '3.11-dev' }}
       run: nox -s lint safety
 
     - name: Run tests
       run: nox -s $TEST_SESSION -- --cov-report=xml
+      continue-on-error: ${{ matrix.pyv == '3.11-dev' }}
       shell: bash
       env:
         TEST_SESSION: ${{ matrix.nox_session || format('tests-{0}', matrix.pyv) }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,18 +45,18 @@ tests =
     pylint==2.14.3
     mypy==0.961
     types-requests==2.28.0
-    fsspec>=2022.02.0; python_version < '3.11'
+    fsspec>=2022.02.0
 
 s3 =
     moto[server]==3.1.16
-    s3fs[boto3]>=2022.02.0; python_version < '3.11'
+    s3fs[boto3]>=2022.02.0
 
 azure =
-    adlfs>=2022.02.22; python_version < '3.11'
+    adlfs>=2022.02.22
     %(docker)s
 
 gcs =
-    gcsfs>=2022.02.22; python_version < '3.11'
+    gcsfs>=2022.02.22
     %(docker)s
 
 docker =


### PR DESCRIPTION
use `continue-on-error` for linting/testing on 3.11.

`universal_pathlib` currently has no 3.11 support, and `fsspec` has spotty support for 3.11 (for example `pip install s3fs` fails due to an `aiohttp` build error).