### PR TITLE
factory: fix memory path usage

### DIFF
--- a/src/pytest_servers/factory.py
+++ b/src/pytest_servers/factory.py
@@ -120,11 +120,13 @@ class TempUPathFactory:
         return path
 
     def memory_temp_path(self, **kwargs) -> UPath:
-        """Creates a new container and returns an UPath instance"""
-        return UPath(
-            f"memory://{random_string()}",
+        """Creates a new temporary in-memory path returns an UPath instance"""
+        path = UPath(
+            f"memory:{random_string()}",
             **kwargs,
         )
+        path.mkdir()
+        return path
 
     def gcs_temp_path(
         self, endpoint_url: Optional[str] = None, **kwargs

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,13 @@
+def test_memory_fs_clean(tmp_upath_factory):
+    mempath1 = tmp_upath_factory.mktemp("memory")
+    mempath2 = tmp_upath_factory.mktemp("memory")
+
+    foo = mempath1 / "foo"
+    foo.write_text("foo")
+    bar = mempath2 / "bar"
+    bar.write_text("bar")
+
+    assert (mempath1 / "foo").exists()
+    assert (mempath2 / "bar").exists()
+    assert not (mempath1 / "bar").exists()
+    assert not (mempath2 / "foo").exists()


### PR DESCRIPTION
When creating an UPath instance with a "memory://" scheme, the first part of the URL (netloc) is ignored by universal pathlib's `MemoryPath`, resulting in all temporary directories pointing to the same location, the root of `MemoryFileSystem`
