### PR TITLE
local: add path attribute to LocalFileSystem

### DIFF
--- a/src/pytest_servers/local.py
+++ b/src/pytest_servers/local.py
@@ -5,3 +5,7 @@ from fsspec.implementations.local import LocalFileSystem
 
 class LocalPath(type(pathlib.Path())):  # type: ignore[misc]
     fs = LocalFileSystem()
+
+    @property
+    def path(self):
+        return str(self)


### PR DESCRIPTION
Makes paths returned by `tmp_upath_factory` more consistent.