### PR TITLE
utils: catch docker-py deprecation warnings

### DIFF
--- a/src/pytest_servers/utils.py
+++ b/src/pytest_servers/utils.py
@@ -51,7 +51,8 @@ def docker_client():
         return
 
     try:
-        yield docker.from_env()
+        with pytest.deprecated_call():
+            yield docker.from_env()
     except docker.errors.DockerException as exc:
         logging.exception(f"Failed to get docker client: {exc}")
         yield None


### PR DESCRIPTION
[`docker-py`](https://github.com/docker/docker-py) uses the deprecated `distutils` module, which results in `DeprecationWarnings` being caught by `pytest` whenever using the `docker_client` fixtures. As a temporary workaround, we just catch the warnings, waiting for either `docker-py` to fix the issue or to remove it entirely