### PR TITLE
fix hang

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ tests =
 
 s3 =
     moto[server]==3.1.16
+    werkzeug==2.1.2 # pinned because of moto issue: https://github.com/spulec/moto/issues/5329
     s3fs[boto3]>=2022.02.0
 
 azure =

--- a/src/pytest_servers/s3.py
+++ b/src/pytest_servers/s3.py
@@ -43,7 +43,9 @@ class MockedS3Server:
         )
         out = self.proc.stderr.readline()
         self.port = int(re.match(b".*http://127.0.0.1:(\\d+).*", out).group(1))
-        wait_until(silent(lambda: requests.get(self.endpoint_url).ok), 5)
+        wait_until(
+            silent(lambda: requests.get(self.endpoint_url, timeout=5).ok), 5
+        )
 
         return self
 


### PR DESCRIPTION
- pin werkzeug to prevent moto server hang (see https://github.com/spulec/moto/issues/5329)
- utils: add timeout to `wait_until` (was masking the above hang)