### PR TITLE
factory: make fixtures lazy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ tests =
 
 s3 =
     moto[server]==3.1.16
+    werkzeug==2.1.2 # pinned because of moto issue: https://github.com/spulec/moto/issues/5329
     s3fs[boto3]>=2022.02.0
 
 azure =

--- a/src/pytest_servers/azure.py
+++ b/src/pytest_servers/azure.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope="session")
 def azurite(docker_client):
+    """Spins up an azurite container. Returns the connection string."""
     if docker_client is None:
         logger.warning(
             "Azurite cannot be started because docker is not available."

--- a/src/pytest_servers/fixtures.py
+++ b/src/pytest_servers/fixtures.py
@@ -19,16 +19,9 @@ def aws_region_name():
 
 
 @pytest.fixture(scope="session")
-def tmp_upath_factory(
-    request: "FixtureRequest", s3_server, azurite, fake_gcs_server
-):
+def tmp_upath_factory(request: "FixtureRequest"):
     """Return a TempUPathFactory instance for the test session."""
-    yield TempUPathFactory.from_config(
-        request.config,
-        s3_endpoint_url=s3_server.endpoint_url,
-        gcs_endpoint_url=fake_gcs_server,
-        azure_connection_string=azurite,
-    )
+    yield TempUPathFactory.from_request(request)
 
 
 @pytest.fixture

--- a/src/pytest_servers/gcs.py
+++ b/src/pytest_servers/gcs.py
@@ -13,6 +13,7 @@ GCS_DEFAULT_PORT = 4443
 
 @pytest.fixture(scope="session")
 def fake_gcs_server(docker_client):
+    """Spins up a fake-gcs-server container. Returns the endpoint URL."""
     if docker_client is None:
         logger.warning(
             "fake-gcs-server cannot run because docker is not available."

--- a/src/pytest_servers/s3.py
+++ b/src/pytest_servers/s3.py
@@ -93,6 +93,6 @@ def s3_fake_creds_file(monkeypatch_session):
 def s3_server(
     s3_fake_creds_file,  # pylint: disable=unused-argument,redefined-outer-name
 ):
-    """Spins up a moto s3 server."""
+    """Spins up a moto s3 server. Returns the endpoint URL."""
     with MockedS3Server() as server:
-        yield server
+        yield server.endpoint_url

--- a/src/pytest_servers/s3.py
+++ b/src/pytest_servers/s3.py
@@ -43,7 +43,9 @@ class MockedS3Server:
         )
         out = self.proc.stderr.readline()
         self.port = int(re.match(b".*http://127.0.0.1:(\\d+).*", out).group(1))
-        wait_until(silent(lambda: requests.get(self.endpoint_url).ok), 5)
+        wait_until(
+            silent(lambda: requests.get(self.endpoint_url, timeout=5).ok), 5
+        )
 
         return self
 


### PR DESCRIPTION
lazily request fixture values in `_mock_remote_setup` so that containers/processes are only started when actually requesting a temporary dir on the given mock remote.