### PR TITLE
Simplify workflow file for 3.11 Python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,6 @@ jobs:
         os: [ubuntu-20.04, windows-latest, macos-latest]
         pyv: ['3.8', '3.9', '3.10']
         include:
-        include:
         - {os: ubuntu-latest, pyv: 'pypy3.8'}
         - {os: ubuntu-latest, pyv: '3.11.0-rc - 3.11', nox_pyv: '3.11'}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,11 +22,9 @@ jobs:
         os: [ubuntu-20.04, windows-latest, macos-latest]
         pyv: ['3.8', '3.9', '3.10']
         include:
-        - os: ubuntu-latest
-          pyv: 'pypy3.8'
-        - os: ubuntu-latest
-          pyv: '3.11-dev'
-          nox_session: 'tests-3.11'
+        include:
+        - {os: ubuntu-latest, pyv: 'pypy3.8'}
+        - {os: ubuntu-latest, pyv: '3.11.0-rc - 3.11', nox_pyv: '3.11'}
 
     steps:
     - name: Check out the repository
@@ -46,15 +44,13 @@ jobs:
         nox --version
 
     - name: Lint code and check dependencies
-      continue-on-error: ${{ matrix.pyv == '3.11-dev' }}
+      continue-on-error: ${{ matrix.nox_pyv == '3.11' }}
       run: nox -s lint safety
 
     - name: Run tests
-      run: nox -s $TEST_SESSION -- --cov-report=xml
-      continue-on-error: ${{ matrix.pyv == '3.11-dev' }}
+      continue-on-error: ${{ matrix.nox_pyv == '3.11' }}
+      run: nox -s tests-${{ matrix.nox_pyv || matrix.pyv }} -- --cov-report=xml
       shell: bash
-      env:
-        TEST_SESSION: ${{ matrix.nox_session || format('tests-{0}', matrix.pyv) }}
 
     - name: Upload coverage report
       uses: codecov/codecov-action@v2.1.0


### PR DESCRIPTION
It's a bit nicer to look at, and selects session directly without using env. Also this will work for any future python versions.

Similar changes were made across different repositories.