### PR TITLE
run tests with coverage for correct coverage reporting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,8 +48,10 @@ jobs:
 
     - name: Run tests
       continue-on-error: ${{ matrix.nox_pyv == '3.11' }}
-      run: nox -s tests-${{ matrix.nox_pyv || matrix.pyv }} -- --cov-report=xml
+      run: nox -s tests-${{ matrix.nox_pyv || matrix.pyv }}
       shell: bash
+      env:
+        COVERAGE_XML: true
 
     - name: Upload coverage report
       uses: codecov/codecov-action@v2.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ docker =
     docker==6.0.0
 
 dev =
+    %(all)s
     %(tests)s
 
 all =


### PR DESCRIPTION
Pytest loads the plugin before the test is run, so we have to start coverage before pytest loads.

See https://github.com/iterative/pytest-servers/runs/7918315266?check_suite_focus=true#step:6:32.