### PR TITLE
tests: fail on any warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ known_first_party = ["pytest_servers"]
 line_length = 79
 
 [tool.pytest.ini_options]
-addopts = "-ra"
+addopts = "-ra -Werror"
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
So that we can find out issues like https://github.com/iterative/pytest-servers/issues/43.