### PR TITLE
add support for pytest-xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ known_first_party = ["pytest_servers"]
 line_length = 79
 
 [tool.pytest.ini_options]
-addopts = "-ra"
+addopts = "-ra -n=auto"
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,9 +76,6 @@ disable = [
     "missing-class-docstring", "raise-missing-from", "import-outside-toplevel",
 ]
 
-[tool.pylint.typecheck]
-signature-mutators = ["funcy.decorators.decorator"]
-
 [tool.pylint.variables]
 dummy-variables-rgx = "_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_"
 ignored-argument-names = "_.*|^ignored_|^unused_|args|kwargs"

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ packages = find:
 install_requires=
     pytest==7.1.2
     dvc-objects>=0.0.13
-    funcy>=1.14
     requests==2.28.1
     universal-pathlib==0.0.19
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ pytest11 =
 tests =
     pytest==7.1.2
     pytest-cov==3.0.0
-    pytest-sugar==0.9.4
+    pytest-sugar==0.9.5
     pytest-xdist==2.5.0
     pylint==2.14.3
     mypy==0.961

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,10 +42,12 @@ tests =
     pytest==7.1.2
     pytest-cov==3.0.0
     pytest-sugar==0.9.4
+    pytest-xdist==2.5.0
     pylint==2.14.3
     mypy==0.961
     types-requests==2.28.9
     fsspec>=2022.02.0
+    filelock==3.8.0
 
 s3 =
     moto[server]==4.0.0

--- a/src/pytest_servers/azure.py
+++ b/src/pytest_servers/azure.py
@@ -1,8 +1,10 @@
 import logging
-import time
 
 import pytest
 import requests
+from filelock import FileLock
+
+from .utils import wait_until, wait_until_running
 
 AZURITE_PORT = 10000
 AZURITE_URL = "http://localhost:{port}"
@@ -15,40 +17,47 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session")
-def azurite(docker_client):
+def azurite(docker_client, tmp_path_factory):
     """Spins up an azurite container. Returns the connection string."""
+    from docker.errors import NotFound
 
-    container = docker_client.containers.run(
-        "mcr.microsoft.com/azure-storage/azurite",
-        command="azurite-blob --loose --blobHost 0.0.0.0",
-        name="pytest-servers-azurite",
-        stdout=True,
-        stderr=True,
-        detach=True,
-        remove=True,
-        ports={f"{AZURITE_PORT}/tcp": None},  # assign a random port
-    )
+    container_name = "pytest-servers-azurite"
+    root_tmp_dir = tmp_path_factory.getbasetemp().parent
+    azurite_lock = root_tmp_dir / "azurite.lock"
 
-    port = docker_client.api.port("pytest-servers-azurite", AZURITE_PORT)[0][
-        "HostPort"
-    ]
-    retries = 3
-    while True:
+    with FileLock(azurite_lock):
         try:
-            # wait until the container is up, even a 400 status code is ok
-            r = requests.get(AZURITE_URL.format(port=port), timeout=10)
-            if (
-                r.status_code == 400
-                and "Server" in r.headers
-                and "Azurite" in r.headers["Server"]
-            ):
-                break
-        except Exception as exc:  # noqa: E722 # pylint: disable=broad-except
-            retries -= 1
-            if retries < 0:
-                raise SystemError from exc
-            time.sleep(1)
+            port = docker_client.api.port(container_name, AZURITE_PORT)[0][
+                "HostPort"
+            ]
+            container = None
+        except NotFound:
+            container = docker_client.containers.run(
+                "mcr.microsoft.com/azure-storage/azurite",
+                command="azurite-blob --loose --blobHost 0.0.0.0",
+                name=container_name,
+                stdout=True,
+                stderr=True,
+                detach=True,
+                remove=True,
+                ports={f"{AZURITE_PORT}/tcp": None},  # assign a random port
+            )
+            port = docker_client.api.port(container_name, AZURITE_PORT)[0][
+                "HostPort"
+            ]
+            wait_until_running(container)
+
+    def is_healthy():
+        r = requests.get(AZURITE_URL.format(port=port), timeout=3)
+        return (
+            r.status_code == 400
+            and "Server" in r.headers
+            and "Azurite" in r.headers["Server"]
+        )
+
+    wait_until(is_healthy, 10)
 
     yield AZURITE_CONNECTION_STRING.format(port=port)
 
-    container.stop()
+    if container is not None:
+        container.stop()

--- a/src/pytest_servers/azure.py
+++ b/src/pytest_servers/azure.py
@@ -58,6 +58,3 @@ def azurite(docker_client, tmp_path_factory):
     wait_until(is_healthy, 10)
 
     yield AZURITE_CONNECTION_STRING.format(port=port)
-
-    if container is not None:
-        container.stop()

--- a/src/pytest_servers/gcs.py
+++ b/src/pytest_servers/gcs.py
@@ -51,6 +51,3 @@ def fake_gcs_server(docker_client, tmp_path_factory):
     wait_until(lambda: requests.get(f"{url}/storage/v1/b", timeout=10).ok, 10)
 
     yield url
-
-    if container is not None:
-        container.stop()

--- a/src/pytest_servers/s3.py
+++ b/src/pytest_servers/s3.py
@@ -4,7 +4,6 @@ import subprocess
 
 import pytest
 import requests
-from funcy import silent
 
 from .utils import wait_until
 
@@ -43,9 +42,7 @@ class MockedS3Server:
         )
         out = self.proc.stderr.readline()
         self.port = int(re.match(b".*http://127.0.0.1:(\\d+).*", out).group(1))
-        wait_until(
-            silent(lambda: requests.get(self.endpoint_url, timeout=5).ok), 5
-        )
+        wait_until(lambda: requests.get(self.endpoint_url, timeout=5).ok, 5)
 
         return self
 

--- a/src/pytest_servers/utils.py
+++ b/src/pytest_servers/utils.py
@@ -15,12 +15,18 @@ logger = logging.getLogger(__name__)
 
 def wait_until(pred, timeout: float, pause: float = 0.1):
     start = time.perf_counter()
+    exc = None
     while (time.perf_counter() - start) < timeout:
-        value = pred()
-        if value:
-            return value
+        try:
+            value = pred()
+        except Exception as e:  # pylint: disable=broad-except
+            exc = e
+        else:
+            if value:
+                return value
         time.sleep(pause)
-    raise TimeoutError("timed out waiting")
+
+    raise TimeoutError("timed out waiting") from exc
 
 
 def random_string(n: int = 6):

--- a/src/pytest_servers/utils.py
+++ b/src/pytest_servers/utils.py
@@ -3,8 +3,12 @@ import random
 import socket
 import string
 import time
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from docker.models.containers import Container
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +47,16 @@ def docker_client():
     yield client
 
     client.close()
+
+
+def wait_until_running(
+    container: "Container", timeout: int = 30, pause: float = 0.5
+):
+    def check():
+        container.reload()
+        return container.status == "running"
+
+    wait_until(check, timeout=timeout, pause=pause)
 
 
 def get_free_port() -> None:


### PR DESCRIPTION
adds support for `pytest-xdist` (or other pytest parallel executors) by making sure that only one of the session-scoped fixtures that spawn docker containers actually spawn new containers.

Note that for now we still might spawn multiple `moto` processes when requesting the the `s3_server_fixture`.