### PR TITLE
Add renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,23 @@
+{
+  "extends": ["group:all", ":dependencyDashboard"],
+  "enabledManagers": ["regex"],
+  "includeForks": true,
+  "regexManagers": [
+    {
+      "fileMatch": ["^src/pytest_servers/gcs.py$"],
+      "matchStrings": [
+        "fake_gcs_image = \"(?<depName>.*?)\"\\s*#",
+        "fake_gcs_tag = \"(?<currentValue>.*?)\"\\s*#"
+      ],
+      "datasourceTemplate": "docker"
+    },
+    {
+      "fileMatch": ["^src/pytest_servers/azure.py$"],
+      "matchStrings": [
+        "azurite_image = \"(?<depName>.*?)\"\\s*#",
+        "azurite_tag = \"(?<currentValue>.*?)\"\\s*#"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ]
+}

--- a/src/pytest_servers/azure.py
+++ b/src/pytest_servers/azure.py
@@ -21,7 +21,10 @@ def azurite(docker_client, tmp_path_factory):
     """Spins up an azurite container. Returns the connection string."""
     from docker.errors import NotFound
 
+    azurite_image = "mcr.microsoft.com/azure-storage/azurite"
+    azurite_tag = "3.18.0"
     container_name = "pytest-servers-azurite"
+
     root_tmp_dir = tmp_path_factory.getbasetemp().parent
     azurite_lock = root_tmp_dir / "azurite.lock"
 
@@ -33,7 +36,7 @@ def azurite(docker_client, tmp_path_factory):
             container = None
         except NotFound:
             container = docker_client.containers.run(
-                "mcr.microsoft.com/azure-storage/azurite",
+                f"{azurite_image}:{azurite_tag}",
                 command="azurite-blob --loose --blobHost 0.0.0.0",
                 name=container_name,
                 stdout=True,

--- a/src/pytest_servers/gcs.py
+++ b/src/pytest_servers/gcs.py
@@ -20,8 +20,11 @@ def fake_gcs_server(docker_client, tmp_path_factory):
     # `fake-gcs-server` to know the actual url it will be accessed
     # with. We can provide that with -public-host and -external-url.
     port = get_free_port()
-    container_port = f"{GCS_DEFAULT_PORT}/tcp"  # FIXME: better name
+
+    fake_gcs_image = "fsouza/fake-gcs-server"
+    fake_gcs_tag = "1.38.0"
     container_name = "pytest-servers-fake-gcs-server"
+
     root_tmp_dir = tmp_path_factory.getbasetemp().parent
     fake_gcs_server_lock = root_tmp_dir / "fake_gcs_server.lock"
 
@@ -36,14 +39,14 @@ def fake_gcs_server(docker_client, tmp_path_factory):
             url = f"http://localhost:{port}"
             command = f"-scheme http -public-host {url} -external-url {url}"
             container = docker_client.containers.run(
-                "fsouza/fake-gcs-server:latest",
+                f"{fake_gcs_image}:{fake_gcs_tag}",
                 name=container_name,
                 command=command,
                 stdout=True,
                 stderr=True,
                 detach=True,
                 remove=True,
-                ports={container_port: port},
+                ports={f"{GCS_DEFAULT_PORT}/tcp": port},
             )
             wait_until_running(container)
 


### PR DESCRIPTION
used to keep docker tags for azurite and fake-gcs-server fixtures up-to-date

closes #56 