### PR TITLE
update universal-pathlib for 3.11 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   FORCE_COLOR: "1"
+  AIOHTTP_NO_EXTENSIONS: 1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -44,11 +45,9 @@ jobs:
         nox --version
 
     - name: Lint code and check dependencies
-      continue-on-error: ${{ matrix.nox_pyv == '3.11' }}
       run: nox -s lint safety
 
     - name: Run tests
-      continue-on-error: ${{ matrix.nox_pyv == '3.11' }}
       run: nox -s tests-${{ matrix.nox_pyv || matrix.pyv }}
       env:
         COVERAGE_XML: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires=
     pytest==7.1.2
     dvc-objects>=0.0.13
     requests==2.28.1
-    universal-pathlib==0.0.19
+    universal-pathlib==0.0.20
 
 [options.entry_points]
 pytest11 =
@@ -41,7 +41,7 @@ tests =
     pytest-cov==3.0.0
     pytest-sugar==0.9.5
     pytest-xdist==2.5.0
-    pylint==2.14.3
+    pylint==2.15.0
     mypy==0.961
     types-requests==2.28.9
     fsspec>=2022.02.0

--- a/src/pytest_servers/s3.py
+++ b/src/pytest_servers/s3.py
@@ -27,7 +27,7 @@ class MockedS3Server:
         """Starts moto s3 on a random port"""
         try:
             # should fail since we didn't start server yet
-            r = requests.get(self.endpoint_url)
+            r = requests.get(self.endpoint_url, timeout=5)
         except:  # noqa: E722, B001 # pylint: disable=bare-except
             pass
         else:


### PR DESCRIPTION
I also removed `continue-on-error`, for which I had to update `pylint` to 2.15.0.

There is `aiohttp` wheel for 3.11, so we have to also set  AIOHTTP_NO_EXTENSIONS to 1 so that we install non-cythonized build (this is only in effect when we install from sdist, otherwise if the wheels exist, they are installed instead. So this is really only going to affect Python 3.11.