### PR TITLE
Fix some dependency issues

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ tests =
     fsspec>=2022.02.0
 
 s3 =
-    moto[server]>=4.0.7
+    moto[server]>=4.0.8
     s3fs[boto3]>=2022.02.0
 
 azure =

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires=
     dvc-objects>=0.0.13
     requests==2.28.1
     universal-pathlib==0.0.21
+    filelock>=3.8.0
 
 [options.entry_points]
 pytest11 =
@@ -44,7 +45,6 @@ tests =
     mypy==0.961
     types-requests==2.28.11.2
     fsspec>=2022.02.0
-    filelock==3.8.0
 
 s3 =
     moto[server]>=4.0.7

--- a/src/pytest_servers/s3.py
+++ b/src/pytest_servers/s3.py
@@ -40,8 +40,16 @@ class MockedS3Server:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        out = self.proc.stderr.readline()
-        self.port = int(re.match(b".*http://127.0.0.1:(\\d+).*", out).group(1))
+        outs = []
+        for _ in range(2):
+            # Depending on the Flask version, the URL is shown on the 1st or 2nd line
+            outs.append(self.proc.stderr.readline())
+            m = re.match(b".*http://127.0.0.1:(\\d+).*", outs[-1])
+            if m:
+                self.port = int(m.group(1))
+                break
+        else:
+            raise RuntimeError(f"Couldn't find moto server port in {outs}")
         wait_until(lambda: requests.get(self.endpoint_url, timeout=5).ok, 5)
 
         return self

--- a/src/pytest_servers/s3.py
+++ b/src/pytest_servers/s3.py
@@ -42,7 +42,8 @@ class MockedS3Server:
         )
         outs = []
         for _ in range(2):
-            # Depending on the Flask version, the URL is shown on the 1st or 2nd line
+            # Depending on the Flask version, the URL is shown on the
+            # 1st or 2nd line
             outs.append(self.proc.stderr.readline())
             m = re.match(b".*http://127.0.0.1:(\\d+).*", outs[-1])
             if m:


### PR DESCRIPTION
* filelock is actually a mandatory dependency
* Until the freshly released moto 4.0.8, the emulation of `list_object_versions` was buggy
* Flask 2.2+ changed the startup message of the moto server