### PR TITLE
s3: use PYTHONWARNINGS=ignore when starting moto

### DIFF
--- a/src/pytest_servers/s3.py
+++ b/src/pytest_servers/s3.py
@@ -1,3 +1,4 @@
+import os
 import re
 import shlex
 import subprocess
@@ -33,12 +34,17 @@ class MockedS3Server:
         else:
             if r.ok:
                 raise RuntimeError("moto server already up")
+
+        # Making sure random warnings don't mess up our stderr parsing.
+        env = {**os.environ, "PYTHONWARNINGS": "ignore"}
+
         self.proc = subprocess.Popen(
             shlex.split(
                 "moto_server s3 -p 0",  # get a random port
             ),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env=env,
         )
         outs = []
         for _ in range(2):


### PR DESCRIPTION
Was getting some random deprecation warnings from openssl and that was messing with s3 fixture.

Wish moto had a better way of spitting a port back at us, but I wasn't able to find anything from a quick look, might contribute at some point in the future if this keeps being so annoying.