### PR TITLE
versioning support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,20 @@ In order to use real remotes instead of mocked ones, use `tmp_upath_factory` wit
 - ``tmp_upath_factory.azure(connection_string)``
 
 
+Versioning support can be used by using the `versioning` fixture. This is currently supported for s3 and gcs remotes
+
+.. code:: python
+
+   # using mktemp
+   def test_something_on_s3_versioned(tmp_upath_factory):
+       path = tmp_upath_factory.mktemp("s3", version_aware=True)
+       assert path.fs.version_aware # bucket has versioning enabled
+
+   # or, using remote-specific fixtures
+   def test_something_on_s3_versioned(tmp_s3_path, versioning):
+       assert tmp_s3_path.fs.version_aware # bucket has versioning enabled
+
+
 Contributing
 ------------
 

--- a/src/pytest_servers/s3.py
+++ b/src/pytest_servers/s3.py
@@ -55,6 +55,7 @@ def s3_fake_creds_file(monkeypatch_session):
             m.setenv("AWS_SECRET_ACCESS_KEY", "pytest-servers")
             m.setenv("AWS_SECURITY_TOKEN", "pytest-servers")
             m.setenv("AWS_SESSION_TOKEN", "pytest-servers")
+            m.setenv("AWS_DEFAULT_REGION", "us-east-1")
             yield
     finally:
         if aws_creds.exists() and not initially_exists:

--- a/src/pytest_servers/utils.py
+++ b/src/pytest_servers/utils.py
@@ -3,17 +3,22 @@ import random
 import socket
 import string
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, TypeVar
 
 import pytest
 
 if TYPE_CHECKING:
     from docker.models.containers import Container
 
+
 logger = logging.getLogger(__name__)
 
+_T = TypeVar("_T")
 
-def wait_until(pred, timeout: float, pause: float = 0.1):
+
+def wait_until(
+    pred: Callable[..., _T], timeout: float, pause: float = 0.1
+) -> _T:
     start = time.perf_counter()
     exc = None
     while (time.perf_counter() - start) < timeout:
@@ -22,14 +27,13 @@ def wait_until(pred, timeout: float, pause: float = 0.1):
         except Exception as e:  # pylint: disable=broad-except
             exc = e
         else:
-            if value:
-                return value
+            return value
         time.sleep(pause)
 
     raise TimeoutError("timed out waiting") from exc
 
 
-def random_string(n: int = 6):
+def random_string(n: int = 6) -> str:
     return "".join(random.choices(string.ascii_lowercase, k=n))  # nosec B311
 
 
@@ -57,7 +61,7 @@ def docker_client():
 
 def wait_until_running(
     container: "Container", timeout: int = 30, pause: float = 0.5
-):
+) -> None:
     def check():
         container.reload()
         return container.status == "running"
@@ -65,7 +69,7 @@ def wait_until_running(
     wait_until(check, timeout=timeout, pause=pause)
 
 
-def get_free_port() -> None:
+def get_free_port() -> int:  # type: ignore[return]
     retries = 3
     while retries >= 0:
         try:

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -31,6 +31,11 @@ implementations = [
 ]
 
 
+with_versioning = [
+    param for param in implementations if param.values[0] in ("s3", "gcs")
+]
+
+
 @pytest.mark.parametrize(
     "fs,cls",
     implementations,
@@ -56,3 +61,14 @@ class TestTmpUPathFactory:
         path_1 = tmp_upath_factory.mktemp(fs)
         path_2 = tmp_upath_factory.mktemp(fs)
         assert str(path_1) != str(path_2)
+
+
+@pytest.mark.parametrize(
+    "fs,cls",
+    with_versioning,
+    ids=[param.values[0] for param in with_versioning],  # type: ignore
+)
+class TestTmpUPathFactoryVersioning:
+    def test_mktemp(self, tmp_upath_factory, fs, cls):
+        path = tmp_upath_factory.mktemp(fs, version_aware=True)
+        assert path.fs.version_aware

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -45,8 +45,7 @@ class TestTmpUPathFactory:
     def test_init(self, tmp_upath_factory, fs, cls):
         path = tmp_upath_factory.mktemp(fs)
         assert isinstance(path, cls)
-        if fs != "gcs":  # for empty buckets on gcs path.exists() == False
-            assert path.exists()
+        assert path.exists()
 
     def test_is_empty(self, tmp_upath_factory, fs, cls):
         path = tmp_upath_factory.mktemp(fs)

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,0 +1,14 @@
+def test_gcs_versioning(tmp_gcs_path, versioning):
+    assert tmp_gcs_path.fs.version_aware
+
+
+def test_gcs_versioning_disabled(tmp_gcs_path):
+    assert not tmp_gcs_path.fs.version_aware
+
+
+def test_s3_versioning(tmp_s3_path, versioning):
+    assert tmp_s3_path.fs.version_aware
+
+
+def test_s3_versioning_disabled(tmp_s3_path):
+    assert not tmp_s3_path.fs.version_aware

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 import os
 from pathlib import Path
 
+from pytest_servers.fixtures import _version_aware
+
 
 def test_s3_fake_creds_file(
     s3_fake_creds_file,  # pylint: disable=unused-argument
@@ -10,4 +12,11 @@ def test_s3_fake_creds_file(
     assert os.getenv("AWS_SECRET_ACCESS_KEY") == "pytest-servers"
     assert os.getenv("AWS_SECURITY_TOKEN") == "pytest-servers"
     assert os.getenv("AWS_SESSION_TOKEN") == "pytest-servers"
+    assert os.getenv("AWS_DEFAULT_REGION") == "us-east-1"
     assert (Path("~").expanduser() / ".aws").exists()
+
+
+def test_version_aware(request):
+    assert not _version_aware(request)
+    request.getfixturevalue("versioning")
+    assert _version_aware(request)


### PR DESCRIPTION
Current usage looks something like this:

```python

def test_on_versioned_s3(tmp_s3_path, versioning):
    assert tmp_s3_path.fs.version_aware
    ...

def test_versioning_generic(tmp_upath_factory):
    tmp_versioned_path = tmp_upath_factory.mktemp("s3", version_aware=True)
    assert tmp_versioned_path.fs.version_aware
``` 

Only `gcs` and `s3` are currently supported.
    