### PR TITLE
Force IPv4 resolution on Windows for MockedS3Server

### DIFF
--- a/src/pytest_servers/s3.py
+++ b/src/pytest_servers/s3.py
@@ -4,7 +4,7 @@ import pytest
 class MockedS3Server:
     def __init__(
         self,
-        ip_address: str = "localhost",
+        ip_address: str = "127.0.0.1",
         port: int = 0,
         verbose: bool = True,
     ):


### PR DESCRIPTION
This avoids IPv6 resolution failures which can cause a massive slow-down on Windows.

Workaround for #105