### PR TITLE
azure: use assume_container_exists=False

### DIFF
--- a/src/pytest_servers/factory.py
+++ b/src/pytest_servers/factory.py
@@ -187,6 +187,9 @@ class TempUPathFactory:
         path = UPath(
             f"az://{container_name}",
             connection_string=connection_string,
+            # To actually get an error instead of a false-positive
+            # "Container exists", see https://github.com/fsspec/adlfs/pull/415
+            assume_container_exists=False,
             **kwargs,
         )
         path.mkdir(parents=True, exist_ok=False)


### PR DESCRIPTION
To actually get an error instead of a false-positive "Container exists" if we encouter an error during container creation  https://github.com/fsspec/adlfs/pull/415