### PR TITLE
factory: don't skip MacOS on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,16 @@ jobs:
     - name: Lint code and check dependencies
       run: nox -s lint safety
 
+    # https://github.com/abiosoft/colima/issues/468
+    - name: Use colima as default docker host on MacOS
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install docker
+        colima start
+        ls -la $HOME/.colima/default/docker.sock
+        sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
+        ls -la /var/run/docker.sock
+
     - name: Run tests
       run: nox -s tests-${{ matrix.nox_pyv || matrix.pyv }}
       env:

--- a/src/pytest_servers/factory.py
+++ b/src/pytest_servers/factory.py
@@ -66,11 +66,6 @@ class TempUPathFactory:
                     "disabled for Windows on Github Actions: "
                     "https://github.com/actions/runner-images/issues/1143"
                 )
-            elif sys.platform == "darwin":
-                pytest.skip(
-                    "disabled for MacOS on Github Actions: "
-                    "https://github.com/actions/runner-images/issues/2150"
-                )
 
         assert self._request
         try:


### PR DESCRIPTION
MacOS images now come with colima installed https://github.com/actions/runner-images/issues/2150

Related https://github.com/iterative/dvc-azure/issues/67
Related https://github.com/iterative/dvc-gs/issues/43