### PR TITLE
gha: increase timeout to 30m

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   tests:
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Windows/MacOS jobs are taking longer than 15m, making CI fail