### PR TITLE
deps: explicitly define botocore to avoid pip backtracking

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ tests =
 s3 =
     moto[server]>=4
     s3fs[boto3]>=2022.02.0
+    botocore>=1.31.17 # Temporary: explicitly define this to avoid pip backtracking while installing moto[server]
 azure =
     adlfs>=2022.02.22
     %(docker)s


### PR DESCRIPTION
installing `moto[server]` causes pip backtracking for `botocore`, explicitly define and pin it to speed up installs.