### PR TITLE
update template

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/iterative/py-template",
-  "commit": "15ee26df315020399731c6291d61bef81a3fc5d3",
+  "commit": "aa59d6c31d258338f4bb9fff8cc1ce9813de7efc",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -13,25 +13,19 @@ repos:
         args: ['--assume-in-merge']
       - id: check-toml
       - id: check-yaml
-      - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
         args: ['--fix=lf']
       - id: sort-simple-yaml
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.1.5'
+    rev: 'v0.1.7'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.5
+    rev: v2.2.6
     hooks:
       - id: codespell
         additional_dependencies: ["tomli"]
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.10.1
-    hooks:
-      - id: pyupgrade
-        args: [--py38-plus]

--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ The `tmp_upath` fixture can be used for parametrizing paths with pytest's indire
 
 .. code:: python
 
-   @pytest.mark.parametrize("tmp_upath", ["local", "s3", "gcs"], indirect=True]) # noqa: E501
+   @pytest.mark.parametrize("tmp_upath", ["local", "s3", "gcs"], indirect=True)
    def test_something(tmp_upath):
        pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,3 +112,27 @@ files = ["src", "tests"]
 
 [tool.codespell]
 ignore-words-list = " "
+
+[tool.ruff]
+ignore = [
+    "S101", # assert
+    "PLR2004", # magic-value-comparison
+    "PLW2901", # redefined-loop-name
+    "ISC001", # single-line-implicit-string-concatenation
+    "SIM105", # suppressible-exception
+    "SIM108", # if-else-block-instead-of-if-exp
+]
+select = ["ALL"]
+show-source = true
+show-fixes = true
+
+[tool.ruff.per-file-ignores]
+"noxfile.py" = ["D", "PTH"]
+"tests/**" = ["S", "ARG001", "ARG002", "ANN"]
+"docs/**" = ["INP"]
+
+[tool.ruff.lint.flake8-type-checking]
+strict = true
+
+[tool.ruff.lint.isort]
+known-first-party = ["pytest_servers"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,8 @@ files = ["src", "tests"]
 ignore-words-list = " "
 
 [tool.ruff]
+line-length = 88
+target-version = "py38"
 ignore = [
     "S101", # assert
     "PLR2004", # magic-value-comparison
@@ -121,6 +123,23 @@ ignore = [
     "ISC001", # single-line-implicit-string-concatenation
     "SIM105", # suppressible-exception
     "SIM108", # if-else-block-instead-of-if-exp
+    "D203", # one blank line before class
+
+    "D213", # multi-line-summary-second-line
+
+    "D100", # missing docstring in public module
+    "D101", # missing docstring in public class
+    "D102", # missing docstring in public method
+    "D103", # missing docstring in public function
+    "D104", # missing docstring in public package
+    "D105", # missing docstring in magic method
+    "D107", # missing docstring in method
+
+    "ANN002", # missing type annotation
+    "ANN101", # missing type annotation
+    "ANN204", # missing return type annotation
+
+    "PT004", # pytest-missing-fixture-name-underscore
 ]
 select = ["ALL"]
 show-source = true
@@ -128,7 +147,21 @@ show-fixes = true
 
 [tool.ruff.per-file-ignores]
 "noxfile.py" = ["D", "PTH"]
-"tests/**" = ["S", "ARG001", "ARG002", "ANN"]
+"tests/**" = [
+    "S",
+     "ARG001",
+     "ARG002",
+     "ANN",
+     "D",
+     "PD011",
+]
+"src/pytest_servers/fixtures.py" = [
+     "PT001", # pytest-fixture-incorrect-parentheses-style
+]
+"src/pytest_servers/factory.py" = [
+    "ANN003", # missing type kwargs
+]
+
 "docs/**" = ["INP"]
 
 [tool.ruff.lint.flake8-type-checking]

--- a/src/pytest_servers/exceptions.py
+++ b/src/pytest_servers/exceptions.py
@@ -1,4 +1,4 @@
-class PytestServersException(Exception):
+class PytestServersException(Exception):  # noqa: N818
     """Base class for all pytest-servers exceptions."""
 
     def __init__(self, msg: str, *args):
@@ -8,4 +8,4 @@ class PytestServersException(Exception):
 
 
 class RemoteUnavailable(PytestServersException):
-    """Raise when the given remote is not available"""
+    """Raise when the given remote is not available."""

--- a/src/pytest_servers/factory.py
+++ b/src/pytest_servers/factory.py
@@ -91,9 +91,13 @@ class TempUPathFactory:
         assert self._request
         try:
             remote_config = self._request.getfixturevalue(mock_remote_fixture)
-        except pytest.FixtureLookupError:
-            msg = f'{fs}: Failed to setup "{mock_remote_fixture}" fixture'
+        except Exception as exc:  # noqa: BLE001
+            msg = f'{fs}: Failed to setup "{mock_remote_fixture}": {exc}'
+            if self._request.config.option.verbose >= 1:
+                raise RemoteUnavailable(msg) from exc
+
             raise RemoteUnavailable(msg) from None
+
         setattr(self, remote_config_name, remote_config)
 
     def mktemp(  # noqa: C901 # complex-structure

--- a/src/pytest_servers/gcs.py
+++ b/src/pytest_servers/gcs.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 import requests
@@ -6,13 +7,19 @@ from filelock import FileLock
 
 from .utils import get_free_port, wait_until, wait_until_running
 
+if TYPE_CHECKING:
+    from docker import DockerClient
+
 logger = logging.getLogger(__name__)
 
 GCS_DEFAULT_PORT = 4443
 
 
 @pytest.fixture(scope="session")
-def fake_gcs_server(docker_client, tmp_path_factory):
+def fake_gcs_server(
+    docker_client: "DockerClient",
+    tmp_path_factory: pytest.TempPathFactory,
+) -> str:
     """Spins up a fake-gcs-server container. Returns the endpoint URL."""
     from docker.errors import NotFound
 
@@ -54,4 +61,4 @@ def fake_gcs_server(docker_client, tmp_path_factory):
     # make sure the container is healthy
     wait_until(lambda: requests.get(f"{url}/storage/v1/b", timeout=10).ok, 10)
 
-    yield url
+    return url

--- a/src/pytest_servers/local.py
+++ b/src/pytest_servers/local.py
@@ -7,5 +7,5 @@ class LocalPath(type(pathlib.Path())):  # type: ignore[misc]
     fs = LocalFileSystem()
 
     @property
-    def path(self):
+    def path(self) -> str:  # noqa: N804
         return str(self)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -39,7 +39,7 @@ with_versioning = [
 @pytest.mark.parametrize(
     "fs,cls",
     implementations,
-    ids=[param.values[0] for param in implementations],  # type: ignore
+    ids=[param.values[0] for param in implementations],  # type: ignore[misc]
 )
 class TestTmpUPathFactory:
     def test_init(self, tmp_upath_factory, fs, cls):
@@ -65,7 +65,7 @@ class TestTmpUPathFactory:
 @pytest.mark.parametrize(
     "fs,cls",
     with_versioning,
-    ids=[param.values[0] for param in with_versioning],  # type: ignore
+    ids=[param.values[0] for param in with_versioning],  # type: ignore[misc]
 )
 class TestTmpUPathFactoryVersioning:
     def test_mktemp(self, tmp_upath_factory, fs, cls):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,9 +4,7 @@ from pathlib import Path
 from pytest_servers.fixtures import _version_aware
 
 
-def test_s3_fake_creds_file(
-    s3_fake_creds_file,  # pylint: disable=unused-argument
-):
+def test_s3_fake_creds_file(s3_fake_creds_file):
     assert os.getenv("AWS_PROFILE") is None
     assert os.getenv("AWS_ACCESS_KEY_ID") == "pytest-servers"
     assert os.getenv("AWS_SECRET_ACCESS_KEY") == "pytest-servers"


### PR DESCRIPTION
- update template
- fix ruff complaints, cleanup
- TmpUPathFactory: handle failures more gracefully: full traceback is only printed when running `pytest -v`
