### PR TITLE
fixtures: remove s3_fake_creds_file, allow for finer boto3 client configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,7 +115,7 @@ The `tmp_upath` fixture can be used for parametrizing paths with pytest's indire
 
 In order to use real remotes instead of mocked ones, use `tmp_upath_factory` with the following methods
 
-- ``tmp_upath_factory.s3(region_name, endpoint_url)``
+- ``tmp_upath_factory.s3(region_name, client_kwargs)`` where client_kwargs are passed to the underlying S3FileSystem/boto client
 - ``tmp_upath_factory.gcs(endpoint_url)``
 - ``tmp_upath_factory.azure(connection_string)``
 

--- a/src/pytest_servers/fixtures.py
+++ b/src/pytest_servers/fixtures.py
@@ -8,7 +8,6 @@ from .factory import TempUPathFactory
 from .gcs import fake_gcs_server  # noqa: F401
 from .s3 import (  # noqa: F401
     MockedS3Server,
-    s3_fake_creds_file,
     s3_server,
     s3_server_config,
 )

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -12,3 +12,11 @@ def test_s3_versioning(tmp_s3_path, versioning):
 
 def test_s3_versioning_disabled(tmp_s3_path):
     assert not tmp_s3_path.fs.version_aware
+
+
+def test_s3_server_default_config(s3_server):
+    assert "endpoint_url" in s3_server
+    assert s3_server["aws_access_key_id"] == "pytest-servers"
+    assert s3_server["aws_secret_access_key"] == "pytest-servers"
+    assert s3_server["aws_session_token"] == "pytest-servers"
+    assert s3_server["region_name"] == "pytest-servers-region"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,17 +1,4 @@
-import os
-from pathlib import Path
-
 from pytest_servers.fixtures import _version_aware
-
-
-def test_s3_fake_creds_file(s3_fake_creds_file):
-    assert os.getenv("AWS_PROFILE") is None
-    assert os.getenv("AWS_ACCESS_KEY_ID") == "pytest-servers"
-    assert os.getenv("AWS_SECRET_ACCESS_KEY") == "pytest-servers"
-    assert os.getenv("AWS_SECURITY_TOKEN") == "pytest-servers"
-    assert os.getenv("AWS_SESSION_TOKEN") == "pytest-servers"
-    assert os.getenv("AWS_DEFAULT_REGION") == "us-east-1"
-    assert (Path("~").expanduser() / ".aws").exists()
 
 
 def test_version_aware(request):


### PR DESCRIPTION
By passing `client_kwargs` to the `s3` temp upath factory, we can avoid having to monkeypatch s3 environment variable for the whole test session.