### PR TITLE
Fix `tmp_path_factory` usage

### DIFF
--- a/src/pytest_servers/factory.py
+++ b/src/pytest_servers/factory.py
@@ -53,17 +53,18 @@ class TempUPathFactory:
     def from_request(
         cls: type[TempUPathFactory],
         request: pytest.FixtureRequest,
+        tmp_path_factory: pytest.TempPathFactory | None = None,
         *args,
         **kwargs,
     ) -> TempUPathFactory:
         """Create a factory according to pytest configuration."""
-        tmp_upath_factory = cls(*args, **kwargs)
-        tmp_upath_factory._local_path_factory = (  # noqa: SLF001
-            pytest.TempPathFactory.from_config(
+        if tmp_path_factory is None:
+            tmp_path_factory = pytest.TempPathFactory.from_config(
                 request.config,
                 _ispytest=True,
             )
-        )
+        tmp_upath_factory = cls(*args, **kwargs)
+        tmp_upath_factory._local_path_factory = tmp_path_factory  # noqa: SLF001
         tmp_upath_factory._request = request  # noqa: SLF001
 
         return tmp_upath_factory

--- a/src/pytest_servers/fixtures.py
+++ b/src/pytest_servers/fixtures.py
@@ -23,9 +23,12 @@ def versioning():  # noqa: ANN201
 
 
 @pytest.fixture(scope="session")
-def tmp_upath_factory(request: pytest.FixtureRequest) -> TempUPathFactory:
+def tmp_upath_factory(
+    request: pytest.FixtureRequest,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> TempUPathFactory:
     """Return a TempUPathFactory instance for the test session."""
-    return TempUPathFactory.from_request(request)
+    return TempUPathFactory.from_request(request, tmp_path_factory)
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes https://github.com/iterative/pytest-servers/issues/157; to be released as <kbd>v0.5.1</kbd>