### PR TITLE
Combine image updates with colima installation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-latest, macos-13]
         pyv: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - {os: ubuntu-latest, pyv: "pypy3.8"}
@@ -49,18 +49,15 @@ jobs:
 
       # https://github.com/abiosoft/colima/issues/468
       - name: Use colima as default docker host on MacOS
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-13'
         run: |
-          brew install docker
+          brew install docker colima 
           colima start
-          ls -la $HOME/.colima/default/docker.sock
-          sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
-          ls -la /var/run/docker.sock
 
       - name: Run tests
         id: tests
         run: nox -s tests-${{ matrix.pyv }}
-        continue-on-error: ${{ matrix.os == 'macos-latest' }}
+        continue-on-error: ${{ matrix.os == 'macos-13' }}
         env:
           COVERAGE_XML: true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-13]
+        os: [ubuntu-20.04, windows-latest, macos-latest]
         pyv: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - {os: ubuntu-latest, pyv: "pypy3.8"}
@@ -47,17 +47,29 @@ jobs:
       - name: Lint code and check dependencies
         run: nox -s lint safety
 
+      # https://github.com/iterative/pytest-servers/pull/122
       # https://github.com/abiosoft/colima/issues/468
+      # https://github.com/abiosoft/colima/blob/main/docs/FAQ.md#cannot-connect-to-the-docker-daemon-at-unixvarrundockersock-is-the-docker-daemon-running
+      # colima v0.5.6 seems to run more stable than the latest - that has occasional network failures (ports are not open)
+      # see: https://github.com/abiosoft/colima/issues/962
       - name: Use colima as default docker host on MacOS
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-latest'
         run: |
-          brew install docker colima 
+          brew install docker lima || true # avoid non-zero exit code if brew link fails
+          sudo curl -L -o /usr/local/bin/colima https://github.com/abiosoft/colima/releases/download/v0.5.6/colima-Darwin-x86_64
+          sudo chmod +x /usr/local/bin/colima
           colima start
+          sudo ln -vsf "${HOME}"/.colima/default/docker.sock /var/run/docker.sock
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: true
+          HOMEBREW_NO_INSTALL_CLEANUP: true
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: true
+          HOMEBREW_NO_INSTALL_UPGRADE: true
 
       - name: Run tests
         id: tests
         run: nox -s tests-${{ matrix.pyv }}
-        continue-on-error: ${{ matrix.os == 'macos-13' }}
+        continue-on-error: ${{ matrix.os == 'macos-latest' }}
         env:
           COVERAGE_XML: true
 

--- a/src/pytest_servers/azure.py
+++ b/src/pytest_servers/azure.py
@@ -42,7 +42,7 @@ def azurite(
             container: Container = docker_client.containers.get(container_name)
         except NotFound:
             container = docker_client.containers.run(
-                "mcr.microsoft.com/azure-storage/azurite:3.29.0",  # renovate
+                "mcr.microsoft.com/azure-storage/azurite:3.30.0",  # renovate
                 command="azurite-blob --loose --blobHost 0.0.0.0",
                 name=container_name,
                 stdout=True,

--- a/src/pytest_servers/gcs.py
+++ b/src/pytest_servers/gcs.py
@@ -50,7 +50,7 @@ def fake_gcs_server(
                 f"-public-host {url} -external-url {url} "
             )
             container = docker_client.containers.run(
-                "fsouza/fake-gcs-server:1.48.0",  # renovate
+                "fsouza/fake-gcs-server:1.49.0",  # renovate
                 name=container_name,
                 command=command,
                 stdout=True,


### PR DESCRIPTION
The pipeline is failing in `dvcx` because the tests depend on this repo and we haven't updated the required dependencies.

~In this PR I have downgraded the `macos` runners to `macos-13` as `macos-14` aka `macos-latest` does not currently support Docker.~

Used the same approach as in `dvcx`

I have also pulled in the image updates from #168 as they are required to make the tests pass and will be needed by `dvcx`.

[Example of failing dependency pipeline](https://github.com/iterative/dvcx/actions/runs/9011591378/job/24759445901).

See [here](https://iterativeai.slack.com/archives/C04A9RWEZBN/p1715223019757329) for more context.