### PR TITLE
Add support for 'gs' as alias for 'gcs' in pytest servers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ The `tmp_upath` fixture can be used for parametrizing paths with pytest's indire
 
 .. code:: python
 
-   @pytest.mark.parametrize("tmp_upath", ["local", "s3", "gcs"], indirect=True)
+   @pytest.mark.parametrize("tmp_upath", ["local", "s3", "gcs", "gs"], indirect=True)
    def test_something(tmp_upath):
        pass
 

--- a/src/pytest_servers/fixtures.py
+++ b/src/pytest_servers/fixtures.py
@@ -102,5 +102,7 @@ def tmp_upath(
         return tmp_upath_factory.mktemp("azure")
     if param == "gcs":
         return tmp_upath_factory.mktemp("gcs", version_aware=version_aware)
+    if param == "gs":
+        return tmp_upath_factory.mktemp("gs", version_aware=version_aware)
     msg = f"unknown {param=}"
     raise ValueError(msg)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -28,11 +28,15 @@ implementations = [
         "gcs",
         upath.implementations.cloud.GCSPath,
     ),
+    pytest.param(
+        "gs",
+        upath.implementations.cloud.GCSPath,
+    ),
 ]
 
 
 with_versioning = [
-    param for param in implementations if param.values[0] in ("s3", "gcs")
+    param for param in implementations if param.values[0] in ("s3", "gcs", "gs")
 ]
 
 
@@ -43,7 +47,7 @@ with_versioning = [
 )
 class TestTmpUPathFactory:
     def test_init(self, tmp_upath_factory, fs, cls):
-        if fs == "gcs":
+        if fs in ("gcs", "gs"):
             pytest.skip("gcsfs does not support .exists() on a bucket")
         path = tmp_upath_factory.mktemp(fs)
         assert isinstance(path, cls)


### PR DESCRIPTION
The commit extends pytest_servers to recognize 'gs' as an alias for 'gcs'. This allows users to use 'gs' as a parameter in pytest. Corresponding test cases have also been updated to reflect this change.
