### PR TITLE
fix(gcs): use host name (not url) for public host

### DIFF
--- a/src/pytest_servers/gcs.py
+++ b/src/pytest_servers/gcs.py
@@ -47,7 +47,7 @@ def fake_gcs_server(
             url = f"http://localhost:{port}"
             command = (
                 "-backend memory -scheme http "
-                f"-public-host {url} -external-url {url} "
+                f"-public-host localhost:{port} -external-url {url} "
             )
             container = docker_client.containers.run(
                 "fsouza/fake-gcs-server:1.50.2",  # renovate


### PR DESCRIPTION
Fixes access to signed URLs, objects, etc (everything that requires usually `storage.googleapis.com`). 