### PR TITLE
ci: add CI success gate job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,3 +82,16 @@ jobs:
 
       - name: Build package
         run: nox -s build
+
+  ci-success:
+    name: CI success
+    runs-on: ubuntu-latest
+    needs: [tests]
+    if: always()
+    steps:
+      - name: Verify all test jobs passed
+        if: needs.tests.result != 'success'
+        run: |
+          echo "Required test jobs did not all succeed: ${{ needs.tests.result }}"
+          exit 1
+      - run: echo "All required test jobs passed."


### PR DESCRIPTION
Adds a single **`CI success`** job that depends on the whole `tests` matrix and fails if any required job didn't succeed.

## Why
So branch protection can require **one** check instead of enumerating every `tests (os, pyv)` job. Adding/removing a Python version or OS no longer requires editing the ruleset.

## Behavior
- `needs: [tests]` + `if: always()` → runs after the matrix and inspects its aggregate result.
- Fails if `needs.tests.result != 'success'`.
- macOS jobs are `continue-on-error`, so they always report success and never fail the gate — preserving the existing "macOS is non-blocking" intent.

## Follow-up (after merge)
Update the `main` ruleset to require only `CI success` and drop the 10 enumerated `tests (...)` contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)