### PR TITLE
docs: refresh README/metadata after org move; status to Beta

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,8 +12,8 @@ Here is a list of important resources for contributors:
 - `Code of Conduct`_
 
 .. _Apache 2.0 license: https://opensource.org/licenses/Apache-2.0
-.. _Source Code: https://github.com/iterative/pytest-servers
-.. _Issue Tracker: https://github.com/iterative/pytest-servers/issues
+.. _Source Code: https://github.com/datachain-ai/pytest-servers
+.. _Issue Tracker: https://github.com/datachain-ai/pytest-servers/issues
 
 How to report a bug
 -------------------
@@ -104,6 +104,6 @@ To run linting and code formatting checks, you can invoke a `lint` session in no
 It is recommended to open an issue before starting work on anything.
 This will allow a chance to talk it over with the owners and validate your approach.
 
-.. _pull request: https://github.com/iterative/pytest-servers/pulls
+.. _pull request: https://github.com/datachain-ai/pytest-servers/pulls
 .. github-only
 .. _Code of Conduct: CODE_OF_CONDUCT.rst

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ pytest servers
 
 |PyPI| |Status| |Python Version| |License|
 
-|Tests| |Codecov| |pre-commit| |Black|
+|Tests| |Codecov| |pre-commit| |Ruff|
 
 .. |PyPI| image:: https://img.shields.io/pypi/v/pytest-servers.svg
    :target: https://pypi.org/project/pytest-servers/
@@ -17,18 +17,18 @@ pytest servers
 .. |License| image:: https://img.shields.io/pypi/l/pytest-servers
    :target: https://opensource.org/licenses/Apache-2.0
    :alt: License
-.. |Tests| image:: https://github.com/iterative/pytest-servers/workflows/Tests/badge.svg
-   :target: https://github.com/iterative/pytest-servers/actions?workflow=Tests
+.. |Tests| image:: https://github.com/datachain-ai/pytest-servers/actions/workflows/tests.yml/badge.svg
+   :target: https://github.com/datachain-ai/pytest-servers/actions/workflows/tests.yml
    :alt: Tests
-.. |Codecov| image:: https://codecov.io/gh/iterative/pytest-servers/branch/main/graph/badge.svg
-   :target: https://app.codecov.io/gh/iterative/pytest-servers
+.. |Codecov| image:: https://codecov.io/gh/datachain-ai/pytest-servers/branch/main/graph/badge.svg
+   :target: https://app.codecov.io/gh/datachain-ai/pytest-servers
    :alt: Codecov
 .. |pre-commit| image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
    :target: https://github.com/pre-commit/pre-commit
    :alt: pre-commit
-.. |Black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
-   :target: https://github.com/psf/black
-   :alt: Black
+.. |Ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
+   :target: https://github.com/astral-sh/ruff
+   :alt: Ruff
 
 
 Features
@@ -38,7 +38,7 @@ Create temporary directories on the following filesystems:
 
 - Local fs
 - In-memory fs
-- S3, both using mock S3 remotes (https://github.com/spulec/moto) and real S3 remotes
+- S3, both using mock S3 remotes (https://github.com/getmoto/moto) and real S3 remotes
 - Azure, both using mock Azure remotes (https://github.com/Azure/Azurite) via docker and using real Azure Storage remotes
 - Google Cloud Storage, both using mock GCS remote (https://github.com/fsouza/fake-gcs-server) via docker and using real Google Storage Remotes
 
@@ -78,7 +78,7 @@ To install all extras:
 Usage
 ------------
 
-The main fixture provided by `pytest-servers` provides is `tmp_upath_factory`, which can be used
+The main fixture provided by `pytest-servers` is `tmp_upath_factory`, which can be used
 to generate temporary paths on different (mocked) filesystems:
 
 .. code:: python
@@ -115,7 +115,7 @@ The `tmp_upath` fixture can be used for parametrizing paths with pytest's indire
 
 In order to use real remotes instead of mocked ones, use `tmp_upath_factory` with the following methods
 
-- ``tmp_upath_factory.s3(region_name, client_kwargs)`` where client_kwargs are passed to the underlying S3FileSystem/boto client
+- ``tmp_upath_factory.s3(client_kwargs)`` where client_kwargs are passed to the underlying S3FileSystem/boto client
 - ``tmp_upath_factory.gcs(endpoint_url)``
 - ``tmp_upath_factory.azure(connection_string)``
 
@@ -154,7 +154,7 @@ please `file an issue`_ along with a detailed description.
 
 .. _Apache 2.0 license: https://opensource.org/licenses/Apache-2.0
 .. _PyPI: https://pypi.org/
-.. _file an issue: https://github.com/iterative/pytest-servers/issues
+.. _file an issue: https://github.com/datachain-ai/pytest-servers/issues
 .. _pip: https://pip.pypa.io/
 .. github-only
 .. _Contributor Guide: CONTRIBUTING.rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Framework :: Pytest",
   "Intended Audience :: Developers"
 ]
@@ -33,8 +33,8 @@ dependencies = [
 pytest-servers = "pytest_servers.fixtures"
 
 [project.urls]
-Issues = "https://github.com/iterative/pytest-servers/issues"
-Source = "https://github.com/iterative/pytest-servers"
+Issues = "https://github.com/datachain-ai/pytest-servers/issues"
+Source = "https://github.com/datachain-ai/pytest-servers"
 
 [project.optional-dependencies]
 docker = ["docker>6"]


### PR DESCRIPTION
## Codecov badge + org move
The repo moved `iterative` → `datachain-ai`, so several badges/links were broken/stale:
- **Codecov** badge + target → `datachain-ai`
- **Tests** badge → `datachain-ai` (also modernized to the `actions/workflows/tests.yml` URL)
- Issue-tracker / `file an issue` / CONTRIBUTING `Source`/`Issue Tracker`/`pull request` links → `datachain-ai`

## Status → Beta
- `Development Status :: 3 - Alpha` → `4 - Beta`. (The README `|Status|` badge is dynamic from PyPI, so it updates after the next release.)

## README review — other outdated info fixed
- **Black → Ruff** badge (the project formats with ruff, not black)
- `tmp_upath_factory.s3(region_name, client_kwargs)` → `s3(client_kwargs)` — `region_name` isn't a parameter; it goes inside `client_kwargs`
- moto link `spulec/moto` → `getmoto/moto`
- typo: "fixture provided by ... provides is" → "is"

Left intentionally: `update-template.yaml` still points to `iterative/py-template` (a separate, still-valid iterative repo), and the workflow comment linking to the historical `pull/122` (redirects fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)