### PR TITLE
chore: linter & automation config hygiene

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: sort-simple-yaml
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.15.18'
+    rev: 'v0.15.20'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ skip = "CODE_OF_CONDUCT.rst"
 
 [tool.ruff]
 line-length = 88
-target-version = "py38"
+target-version = "py310"
 output-format = "full"
 show-fixes = true
 
@@ -127,7 +127,8 @@ ignore = [
   "S101",  # assert
   "PLR2004",  # magic-value-comparison
   "PLW2901",  # redefined-loop-name
-  "ISC001",  # single-line-implicit-string-concatenation
+  "ISC001",  # single-line-implicit-string-concatenation (conflicts with formatter)
+  "COM812",  # missing-trailing-comma (conflicts with formatter)
   "SIM105",  # suppressible-exception
   "SIM108",  # if-else-block-instead-of-if-exp
   "D203",  # one blank line before class

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,9 @@
 {
   "extends": ["group:all", ":dependencyDashboard"],
-  "enabledManagers": ["regex"],
-  "regexManagers": [
+  "enabledManagers": ["custom.regex"],
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": [
         "^src/pytest_servers/gcs.py$",
         "^src/pytest_servers/azure.py$"

--- a/src/pytest_servers/utils.py
+++ b/src/pytest_servers/utils.py
@@ -3,7 +3,8 @@ import random
 import socket
 import string
 import time
-from typing import TYPE_CHECKING, Callable, NamedTuple, TypeVar
+from collections.abc import Callable
+from typing import TYPE_CHECKING, NamedTuple, TypeVar
 
 import pytest
 


### PR DESCRIPTION
Review of linters + dependabot/renovate, keeping things current and clean.

## ruff
- **`target-version` was `py38`** but the project requires `>=3.10`. Bumped to **`py310`** so ruff applies modern idioms. Surfaced + auto-fixed `UP035` (import `Callable` from `collections.abc`) in `utils.py`.
- **Ignore `COM812`** (missing-trailing-comma) — with `select = ["ALL"]` it's enabled and **conflicts with `ruff-format`** (ruff emits a warning on every run). `ISC001` was already ignored for the same reason.
- Bumped **ruff-pre-commit `0.15.18` → `0.15.20`** (latest).

## renovate
- Migrated the **deprecated `regexManagers`** to **`customManagers`** (`customType: "regex"`) and `enabledManagers: ["regex"]` → `["custom.regex"]`. Behavior is unchanged (still tracks the `# renovate`-tagged docker tags in `gcs.py`/`azure.py`), but it stops using deprecated config.

## Verified
- `ruff check` ✅, `ruff format --check` ✅ (no more COM812 conflict warning), `mypy 2.1.0` ✅.
- `renovate.json` is valid JSON; markers confirmed present in `gcs.py`/`azure.py`.

## Notes (not changed here)
- `select = ["ALL"]` means each ruff upgrade can auto-enable new rules and break CI on `pre-commit.ci` autoupdate — kept as-is (deliberate), just flagging.
- dependabot (`pip` + `github-actions`, weekly) is fine; could add `groups:` later to reduce PR noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)